### PR TITLE
Add customizable tags

### DIFF
--- a/rundeck-puppetdb-nodes-plugin/contents/rundeck_puppetdb_nodes.py
+++ b/rundeck-puppetdb-nodes-plugin/contents/rundeck_puppetdb_nodes.py
@@ -49,12 +49,13 @@ class PuppetDBNodes(object):
             return None
 
 
-    def print_puppetdb_nodes(self, apiurl, hostgroup, factlist):
+    def print_puppetdb_nodes(self, apiurl, hostgroup, factlist, taglist):
         '''
         Queries PuppetDB and prints out the nodes information in a supported format for Rundeck
 .
         '''
         factlist.extend(["operatingsystem", "operatingsystemrelease", "hostgroup"])
+        factlist.extend(taglist)
         raw_data = self.get_facts_puppetdb(apiurl, factlist, hostgroup)
         data = defaultdict(lambda: {})
 
@@ -67,22 +68,26 @@ class PuppetDBNodes(object):
                 print ('%s:'%node)
                 print (" "*4 + "hostname: " + node)
                 print (" "*4 + "username: root")
+                print (" "*4 + "tags: %s" % ",".join([data[node][tag] for tag in
+                    taglist if data[node].has_key(tag)]))
                 for fact in factlist:
                     if data[node].has_key(fact):
                         print (" "*4 + fact + ": " + data[node][fact] )
+
             logging.info("Node list printed successfully")
 
         else:
             logging.error("Fact list empty. Check PuppetDB connection params")
 
 
-    def store_puppetdb_nodes(self, apiurl, hostgroup, factlist, filename):
+    def store_puppetdb_nodes(self, apiurl, hostgroup, factlist, taglist, filename):
         '''
         Instead of querying PuppetDB every time, saves the list of nodes on a local file
         so Rundeck can access it localy.
 
         '''
         factlist.extend(["operatingsystem", "operatingsystemrelease", "hostgroup"])
+        factlist.extend(taglist)
         raw_data = self.get_facts_puppetdb(apiurl, factlist, hostgroup)
         data = defaultdict(lambda: {})
 
@@ -96,6 +101,8 @@ class PuppetDBNodes(object):
                     file.write('%s:\n'%node)
                     file.write(" "*4 + "hostname: " + node + '\n')
                     file.write(" "*4 + "username: root" + '\n')
+                    print (" "*4 + "tags: %s" % ",".join([data[node][tag] for
+                        tag in taglist if data[node].has_key(tag)]))
                     for fact in factlist:
                         if data[node].has_key(fact):
                             file.write(" "*4 + fact + ": " + data[node][fact] + '\n')
@@ -107,21 +114,24 @@ class PuppetDBNodes(object):
     def run(self):
         self.negociate_krb_ticket(self.keytab, self.username)
         if self.store:
-            self.store_puppetdb_nodes(self.apiurl, self.hostgroup, self.factlist, self.file)
+            self.store_puppetdb_nodes(self.apiurl, self.hostgroup, self.factlist,
+                self.taglist, self.file)
         else:
-            self.print_puppetdb_nodes(self.apiurl, self.hostgroup, self.factlist)
+            self.print_puppetdb_nodes(self.apiurl, self.hostgroup, self.factlist,
+                self.taglist)
 
 
 def main():
     parser = ArgumentParser(description="Populate Rundeck list of nodes from PuppetDB")
     parser.add_argument("-v", "--verbose", help="increase output verbosity", action="store_true")
     parser.add_argument("-d", "--debug", help="increase output to debug messages", action="store_true")
- 
+
     parser.add_argument("--apiurl", help="PuppetDB API url (https://<SERVER>:<PORT>/<API VERSION>)", required=True)
     parser.add_argument("--hostgroup", help="Foreman hostgroup", required=True)
     parser.add_argument("--keytab", help="Keytab", required=True)
     parser.add_argument("--username", help="Username to connect to PuppetDB", required=True)
     parser.add_argument("--factlist", nargs='*', default=[], help="List of facts to retrieve for every node")
+    parser.add_argument("--taglist", nargs='*', default=[], help="List of tags to add for every node")
     parser.add_argument("--file", default="/tmp/nodes.yaml", help="File path where the node list info will be stored")
 
     behaviour = parser.add_mutually_exclusive_group()
@@ -133,6 +143,9 @@ def main():
     #trick to get the factlist as an object list when called it from Rundeck
     if len(args.factlist) == 1:
         args.factlist = args.factlist[0].split()
+
+    if len(args.taglist) == 1:
+        args.taglist = args.taglist[0].split()
 
     if args.verbose:
         logging.basicConfig(level=logging.INFO)

--- a/rundeck-puppetdb-nodes-plugin/plugin.yaml
+++ b/rundeck-puppetdb-nodes-plugin/plugin.yaml
@@ -1,10 +1,10 @@
 #yaml plugin metadata
 
 name: PuppetDB source
-version: 1.2
+version: 1.3
 rundeckPluginVersion: 1.0
 author: Daniel Fernandez (danielfr@cern.ch)
-date: 2016/02/25
+date: 2016/09/05
 providers:
         - name: rundeck-puppetdb-nodes
           service: ResourceModelSource
@@ -14,7 +14,7 @@ providers:
           plugin-type: script
           script-interpreter: /usr/bin/python
           script-file: rundeck_puppetdb_nodes.py
-          script-args: "-v --apiurl ${config.apiurl} --hostgroup ${config.hostgroup} --username ${config.username} --keytab ${config.keytab} --file ${config.file} --${config.mode} --factlist ${config.factlist}"
+          script-args: "-v --apiurl ${config.apiurl} --hostgroup ${config.hostgroup} --username ${config.username} --keytab ${config.keytab} --file ${config.file} --${config.mode} --factlist ${config.factlist} --taglist ${config.taglist}"
           config:
                 - name: apiurl
                   type: String
@@ -42,6 +42,12 @@ providers:
                   title: Fact list
                   description: "Space-separated list of facts to retrieve for every node"
                   default: "hostname ipaddress"
+                  required: false
+                - name: taglist
+                  type: String
+                  title: Tag list
+                  description: "Space-separated list of facts whose values(!) will be added as tags"
+                  default: ""
                   required: false
                 - name: mode
                   type: Select


### PR DESCRIPTION
Add a new field `taglist`to the plugin configuration page. The fact names added to this list will be queried and their values (and values only) will be added as tags to the nodes in rundeck.
