### PR TITLE
Use inventory endpoint, explode hostgroup query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v3.0.0](https://github.com/cernops/rundeck-puppetdb-nodes/tree/v3.0.0)
+- Use PDB /inventory endpoint
+- Explode full hostgroup and query with hostgroup elements
+
 ## [v2.1.0](https://github.com/cernops/rundeck-puppetdb-nodes/tree/v2.1.0)
 
 - Set custom user-agent for puppetdb requests to "rundeck_puppetdb_nodes"

--- a/rundeck-puppetdb-nodes-plugin/plugin.yaml
+++ b/rundeck-puppetdb-nodes-plugin/plugin.yaml
@@ -1,9 +1,9 @@
 #yaml plugin metadata
 
 name: PuppetDB source
-version: 2.1.0
+version: 3.0.0
 rundeckPluginVersion: 1.0
-author: Daniel Fernandez, David Moreno Garcia, Philippe Ganz, Nacho Barrientos Arias (nacho.barrientos@cern.ch), Ignacio Coterillo Coz (ignacio.coterillo.coz@cern.ch)
+author: Daniel Fernandez, David Moreno Garcia, Philippe Ganz, Nacho Barrientos Arias (nacho.barrientos@cern.ch), Ignacio Coterillo Coz (ignacio.coterillo.coz@cern.ch), Steve Traylen (steve.traylen@cern.ch)
 date: 2021/08/04
 providers:
         - name: rundeck-puppetdb-nodes


### PR DESCRIPTION
Rather than user `/pdb/query/v4/facts` use an inventory query to `pdb/query/v4`.

Also a change of behaviour previously the hostgroup `a/b/c` was searched as a regex for `a/b/c` in the hostgroup.

Instead a hostgroup such as `a/b/c` is exploded to become a search of `hostgroup_0=a`, `hostgroup_1=b` and `hostgroup_2=c`.

Both of these changes are to improve performance.

Currently all queries are one of the following:

* `hg_a`
* `hg_a/hg_b`
* `hg_a/`    with a trailing slash.

and will work with exploding the query to searching for exact hostgroup parts.


