### PR TITLE
Set a user agent for the requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [v2.1.0](https://github.com/cernops/rundeck-puppetdb-nodes/tree/v2.1.0)
+
+- Set custom user-agent for puppetdb requests to "rundeck_puppetdb_nodes"

--- a/rundeck-puppetdb-nodes-plugin/contents/rundeck_puppetdb_nodes.py
+++ b/rundeck-puppetdb-nodes-plugin/contents/rundeck_puppetdb_nodes.py
@@ -36,7 +36,11 @@ class PuppetDBNodes():
         query_facts = ','.join(['["=","name","%s"]' % fact for fact in facts])
         query = query_base % (query_facts, hostgroup)
 
-        headers = {'Content-Type': 'application/json','Accept': 'application/json, version=2'}
+        headers = {
+                'Content-Type': 'application/json',
+                'Accept': 'application/json, version=2',
+                'User-Agent': 'rundeck_puppetdb_nodes/2.1.0'
+                }
         payload = {'query': query}
 
         logging.info("Getting facts from '%s', query: '%s'", url, query)

--- a/rundeck-puppetdb-nodes-plugin/plugin.yaml
+++ b/rundeck-puppetdb-nodes-plugin/plugin.yaml
@@ -1,7 +1,7 @@
 #yaml plugin metadata
 
 name: PuppetDB source
-version: 2.0.0
+version: 2.1.0
 rundeckPluginVersion: 1.0
 author: Daniel Fernandez, David Moreno Garcia, Philippe Ganz, Nacho Barrientos Arias (nacho.barrientos@cern.ch), Ignacio Coterillo Coz (ignacio.coterillo.coz@cern.ch)
 date: 2021/08/04


### PR DESCRIPTION
It's userful to be able to distinguish in PuppetDB which requests come from this plugin.

Set a user-agent identifying this plugin.

Its unfortuantly not passible as far as I can see to access the version from the yaml in the python :-(