### PR TITLE
Expose keys with and without "facts" prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+- Expose both "fact" and "facts.fact" as keys.
+- Use non legacy facts in query
+- Maintain old legacy facts "operatingsystem" and "operatingsystemrelease"
+  derived from their non-legacy fact versions.
+
 ## [v3.0.0](https://github.com/cernops/rundeck-puppetdb-nodes/tree/v3.0.0)
 - Use PDB /inventory endpoint
 - Explode full hostgroup and query with hostgroup elements

--- a/README.md
+++ b/README.md
@@ -49,57 +49,54 @@ Download the latest .ZIP from the [releases page](https://github.com/cernops/run
 
 Next time you log in, you will see a new Resource Model Source called **PuppetDB Source** on the project's configuration page.
 
+Running Plugin Manually
+-----------------------
+
+```bash
+python3 rundeck_puppetdb_nodes.py --verbose --apiurl https://pdb.example.ch:9081/pdb/query/v4 \
+    --hostgroup one/two\
+    --krbuser $USER --sshuser $USER \
+    --keytab /tmp/foo \
+    --store --file /tmp/foo.yaml
+```
+
+or
+
+```bash
+python3 rundeck_puppetdb_nodes.py --verbose --apiurl https://pdb.example.ch:9081/pdb/query/v4 \
+    --hostgroup one/two\
+    --krbuser $USER --sshuser $USER \
+    --keytab /tmp/foo \
+```
+
 Plugin Output example
 ---------------------
-```
-scheduler-02.mydomain.com:
-    hostname: scheduler-02.mydomain.com
-    username: root
-    tags:  hostgroup=workflows/scheduler/server
-    osName: SLC
-scheduler-01.mydomain.com:
-    hostname: scheduler-01.mydomain.com
-    username: root
-    tags:  hostgroup=workflows/scheduler/server
-    osName: SLC
-loadbalancer-01.mydomain.com:
-    hostname: loadbalancer-01.mydomain.com
-    username: root
-    tags:  hostgroup=workflows/ha
-    osName: SLC
-server-02.mydomain.com:
-    hostname: server-02.mydomain.com
-    username: root
-    tags:  hostgroup=workflows/server/production
-    osName: SLC
-loadbalancer-02.mydomain.com:
-    hostname: loadbalancer-02.mydomain.com
-    username: root
-    tags:  hostgroup=workflows/ha
-    osName: SLC
-server-qa-01.mydomain.com:
-    hostname: server-qa-01.mydomain.com
-    username: root
-    tags:  hostgroup=workflows/server/qa
-    osName: SLC
-loadbalancer-qa-01.mydomain.com:
-    hostname: loadbalancer-qa-01.mydomain.com
-    username: root
-    tags:  hostgroup=workflows/ha
-    osName: SLC
-server-qa-03.mydomain.com:
-    hostname: server-qa-03.mydomain.com
-    username: root
-    tags:  hostgroup=workflows/server
-    osName: CentOS
-server-datastore.mydomain.com:
-    hostname: server-datastore.mydomain.com
-    username: root
-    tags:  hostgroup=workflows/datastore
-    osName: CentOS
-server-qa-02.mydomain.com:
-    hostname: server-qa-02.mydomain.com
-    username: root
-    tags:  hostgroup=workflows/server
-    osName: SLC
+
+```yaml
+nodeA.example.ch:
+    hostname: nodeA.example.ch
+    username: fred
+    os.name: RedHat
+    facts.os.name: RedHat
+    os.release.full: 9.5
+    facts.os.release.full: 9.5
+    hostgroup: one/two/login
+    facts.hostgroup: one/two/login
+    facts.operatingsystem: RedHat
+    operatingsystem: RedHat
+    facts.operatingsystemrelease: 9.5
+    operatingsystemrelease: 9.5
+nodeB.example.ch:
+    hostname: nodeB.example.ch
+    username: straylen
+    os.name: RedHat
+    facts.os.name: RedHat
+    os.release.full: 9.5
+    facts.os.release.full: 9.5
+    hostgroup: one/two/login
+    facts.hostgroup: one/two/login
+    facts.operatingsystem: RedHat
+    operatingsystem: RedHat
+    facts.operatingsystemrelease: 9.5
+    operatingsystemrelease: 9.5
 ```

--- a/rundeck-puppetdb-nodes-plugin/contents/rundeck_puppetdb_nodes.py
+++ b/rundeck-puppetdb-nodes-plugin/contents/rundeck_puppetdb_nodes.py
@@ -61,7 +61,7 @@ class PuppetDBNodes():
         Queries PuppetDB and prints out the nodes information in a supported format for Rundeck
 .
         '''
-        factlist.extend(["operatingsystem", "operatingsystemrelease", "hostgroup"])
+        factlist.extend(["os.name", "os.release.full", "hostgroup"])
         raw_data = self.get_facts_puppetdb(apiurl, factlist, hostgroup)
         data = defaultdict(lambda: {})
 
@@ -74,7 +74,13 @@ class PuppetDBNodes():
                 for fact in factlist:
                     factkey = "facts.%s" % fact
                     if factkey in entry:
+                        print(" "*4 + fact + ": " + str(entry[factkey]))
                         print(" "*4 + factkey + ": " + str(entry[factkey]))
+                # legacy facts
+                print(" "*4 + "facts.operatingsystem" + ": " + str(entry["facts.os.name"]))
+                print(" "*4 + "operatingsystem" + ": " + str(entry["facts.os.name"]))
+                print(" "*4 + "facts.operatingsystemrelease" + ": " + str(entry["facts.os.release.full"]))
+                print(" "*4 + "operatingsystemrelease" + ": " + str(entry["facts.os.release.full"]))
 
             logging.info("Node list printed successfully")
 
@@ -88,7 +94,7 @@ class PuppetDBNodes():
         so Rundeck can access it localy.
 
         '''
-        factlist.extend(["operatingsystem", "operatingsystemrelease", "hostgroup"])
+        factlist.extend(["os.name", "os.release.full", "hostgroup"])
         raw_data = self.get_facts_puppetdb(apiurl, factlist, hostgroup)
 
         if raw_data != None:
@@ -101,7 +107,14 @@ class PuppetDBNodes():
                     for fact in factlist:
                         factkey = "facts.%s" % fact
                         if factkey in entry:
+                            file.write(" "*4 + fact + ": " + str(entry[factkey]) + '\n')
                             file.write(" "*4 + factkey + ": " + str(entry[factkey]) + '\n')
+                # legacy facts
+                file.write(" "*4 + "facts.operatingsystem" + ": " + str(entry["facts.os.name"]))
+                file.write(" "*4 + "operatingsystem" + ": " + str(entry["facts.os.name"]))
+                file.write(" "*4 + "facts.operatingsystemrelease" + ": " + str(entry["facts.os.release.full"]))
+                file.write(" "*4 + "operatingsystemrelease" + ": " + str(entry["facts.os.release.full"]))
+
             logging.info('Node list saved successfully')
 
             # trick to avoid Rundeck complain when no output is printed out


### PR DESCRIPTION
Version 3.0.0 introduced a change in behaviour that keys changed from `hostgroup` and `operatingsystem` to `facts.hostgroup` and `facts.operatingsystem`.

With this change we now expose keys in both styles.

In addition all default queries use non-legacy facts with both the new and old facts still available in the yaml output.

Example output:

```yaml
nodeA.example.ch:
    hostname: nodeA.example.ch
    username: fred
    os.name: RedHat
    facts.os.name: RedHat
    os.release.full: 9.5
    facts.os.release.full: 9.5
    hostgroup: one/two/login
    facts.hostgroup: one/two/login
    facts.operatingsystem: RedHat
    operatingsystem: RedHat
    facts.operatingsystemrelease: 9.5
    operatingsystemrelease: 9.5
```